### PR TITLE
Fix passing a null parameter to debug_backtrace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -46,7 +46,10 @@
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
+        }
     },
     "extra": {
         "laravel": {

--- a/config/query-tracer.php
+++ b/config/query-tracer.php
@@ -124,14 +124,14 @@ return [
         | Backtrace Frame Limit
         |--------------------------------------------------------------------------
         |
-        | Setting this limit to any non-null value greater than 0 will limit the
-        | amount of stack frames to parse. Depending on the application and your
-        | restriction settings, a good value might be between 8 and 25. If in
-        | doubt, leave this setting unlimited as long as you don't experience
-        | serious performance or memory consumption issues.
+        | Setting this limit to any value greater than 0 will limit the amount
+        | of stack frames to parse. Depending on the application and your
+        | restriction settings, a good value might be between 8 and 25.
+        | If in doubt, leave this setting unlimited as long as you do
+        | not experience performance or memory consumption issues.
         |
         */
-        'limit' => null,
+        'limit' => 0,
 
         /*
         |--------------------------------------------------------------------------

--- a/src/Classes/StackTrace.php
+++ b/src/Classes/StackTrace.php
@@ -91,7 +91,7 @@ class StackTrace
 
         $fullBacktrace = debug_backtrace(
             config('query-tracer.backtrace.withArgs') ? 1 : DEBUG_BACKTRACE_IGNORE_ARGS,
-            config('query-tracer.backtrace.limit')
+            config('query-tracer.backtrace.limit') ?? 0
         );
 
         $stackFrameIterator = new ArrayIterator($fullBacktrace);

--- a/src/Classes/StackTrace.php
+++ b/src/Classes/StackTrace.php
@@ -90,8 +90,8 @@ class StackTrace
         $excludeContaining = (array)config('query-tracer.backtrace.excludeFilesContaining');
 
         $fullBacktrace = debug_backtrace(
-            config('query-tracer.backtrace.withArgs') ? 1 : DEBUG_BACKTRACE_IGNORE_ARGS,
-            config('query-tracer.backtrace.limit') ?? 0
+            DEBUG_BACKTRACE_PROVIDE_OBJECT | (config('query-tracer.backtrace.withArgs') ? false : DEBUG_BACKTRACE_IGNORE_ARGS),
+            config('query-tracer.backtrace.limit')
         );
 
         $stackFrameIterator = new ArrayIterator($fullBacktrace);

--- a/src/Classes/StackTrace.php
+++ b/src/Classes/StackTrace.php
@@ -135,7 +135,7 @@ class StackTrace
 
         $args = '';
 
-        if (is_array($stackFrame['args']) && count($stackFrame['args'])) {
+        if (is_array($stackFrame['args'] ?? false) && count($stackFrame['args'])) {
             $args = app('trace.formatter.argument')->formatStackFrameArguments(array_values($stackFrame['args']));
         }
 


### PR DESCRIPTION
This PR fixes passing null for the limit parameter to debug_backtrace, which will cause a deprecation exception in PHP 8.1 on a test run with the default config (where limit is set to null).

Kind of odd it didn't break before, maybe the RCs of 8.1 didn't handle that yet.